### PR TITLE
implement worklog functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ MCP tools use `snake_case` names, `camelCase` parameters, and return Markdown-fo
 - **jira_ls_comments**: Lists comments for an issue (`issueIdOrKey`: str req, `limit`: num opt, `startAt`: num opt, `orderBy`: str opt). Use: Read issue discussion.
 - **jira_add_comment**: Adds comment to an issue (`issueIdOrKey`: str req, `commentBody`: str req). Use: Add feedback to issues.
 - **jira_ls_statuses**: Lists available workflow statuses (`projectKeyOrId`: str opt). Use: Check valid status transitions.
+- **jira_ls_worklogs**: Lists worklogs for a specific issue (`issueIdOrKey`: str req). Use: View time tracking entries.
+- **jira_add_worklog**: Adds a worklog to an issue (`issueIdOrKey`: str req, `timeSpentSeconds`: num req, `comment`: str opt, `started`: str opt). Use: Log time spent on tasks.
 
 <details>
 <summary><b>MCP Tool Examples (Click to expand)</b></summary>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@aashari/mcp-server-atlassian-jira",
-	"version": "1.35.4",
+	"version": "1.35.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@aashari/mcp-server-atlassian-jira",
-			"version": "1.35.4",
+			"version": "1.35.6",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/src/controllers/atlassian.worklogs.controller.ts
+++ b/src/controllers/atlassian.worklogs.controller.ts
@@ -1,0 +1,154 @@
+import { Logger } from '../utils/logger.util.js';
+import { getAtlassianCredentials } from '../utils/transport.util.js';
+import {
+  handleControllerError,
+  buildErrorContext,
+} from '../utils/error-handler.util.js';
+import { ControllerResponse } from '../types/common.types.js';
+import {
+  AddWorklogParams,
+  GetWorklogsParams,
+  WorklogResponse,
+  Worklog,
+} from '../tools/atlassian.worklogs.types.js';
+import { fetchAtlassian } from '../utils/transport.util.js';
+
+// Create a contextualized logger for this file
+const controllerLogger = Logger.forContext(
+  'controllers/atlassian.worklogs.controller.ts',
+);
+
+// Log controller initialization
+controllerLogger.debug('Jira worklogs controller initialized');
+
+async function getWorklogs(
+  params: GetWorklogsParams,
+): Promise<ControllerResponse> {
+  const methodLogger = Logger.forContext(
+    'controllers/atlassian.worklogs.controller.ts',
+    'getWorklogs',
+  );
+  methodLogger.debug(`Getting worklogs for issue: ${params.issueIdOrKey}`);
+
+  try {
+    const credentials = getAtlassianCredentials();
+    if (!credentials) {
+      throw new Error('Atlassian credentials are required for this operation');
+    }
+
+    const data = await fetchAtlassian<WorklogResponse>(
+      credentials,
+      `/rest/api/3/issue/${params.issueIdOrKey}/worklog`,
+      { method: 'GET' }
+    );
+
+    return {
+      content: `# Worklogs for ${params.issueIdOrKey}\n\n${formatWorklogs(data.worklogs)}`,
+    };
+  } catch (error) {
+    return handleControllerError(
+      error,
+      buildErrorContext(
+        'Worklog',
+        'getWorklogs',
+        'controllers/atlassian.worklogs.controller.ts',
+        params.issueIdOrKey
+      )
+    );
+  }
+}
+
+async function addWorklog(
+  params: AddWorklogParams,
+): Promise<ControllerResponse> {
+  const methodLogger = Logger.forContext(
+    'controllers/atlassian.worklogs.controller.ts',
+    'addWorklog',
+  );
+  methodLogger.debug(`Adding worklog to issue: ${params.issueIdOrKey}`);
+
+  try {
+    const credentials = getAtlassianCredentials();
+    if (!credentials) {
+      throw new Error('Atlassian credentials are required for this operation');
+    }
+
+    const payload = {
+      timeSpentSeconds: params.timeSpentSeconds,
+      started: params.started || new Date().toISOString(),
+      comment: params.comment
+        ? {
+            type: 'doc',
+            version: 1,
+            content: [
+              {
+                type: 'paragraph',
+                content: [
+                  {
+                    type: 'text',
+                    text: params.comment,
+                  },
+                ],
+              },
+            ],
+          }
+        : undefined,
+    };
+
+    /* const data =*/ await fetchAtlassian<Worklog>(
+      credentials,
+      `/rest/api/3/issue/${params.issueIdOrKey}/worklog`,
+      {
+        method: 'POST',
+        body: payload,
+      }
+    );
+
+    return {
+      content: `# Worklog Added Successfully\n\nWorklog has been added to issue ${params.issueIdOrKey}\n\n## Details\n- Time Spent: ${formatSeconds(params.timeSpentSeconds)}\n- Started: ${params.started || 'Now'}\n${params.comment ? `- Comment: ${params.comment}` : ''}`,
+    };
+  } catch (error) {
+    return handleControllerError(
+      error,
+      buildErrorContext(
+        'Worklog',
+        'addWorklog',
+        'controllers/atlassian.worklogs.controller.ts',
+        params.issueIdOrKey
+      )
+    );
+  }
+}
+
+function formatSeconds(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  
+  if (hours > 0 && minutes > 0) {
+    return `${hours}h ${minutes}m`;
+  } else if (hours > 0) {
+    return `${hours}h`;
+  } else {
+    return `${minutes}m`;
+  }
+}
+
+function formatWorklogs(worklogs: any[]): string {
+  if (!worklogs || worklogs.length === 0) {
+    return '*No worklogs found*';
+  }
+
+  return worklogs.map(worklog => {
+    const timeSpent = formatSeconds(worklog.timeSpentSeconds);
+    const author = worklog.author.displayName;
+    const started = new Date(worklog.started).toISOString();
+    const comment = worklog.comment?.content?.[0]?.content?.[0]?.text || 'No comment';
+
+    return `## Worklog by ${author}\n- Time Spent: ${timeSpent}\n- Started: ${started}\n- Comment: ${comment}\n`;
+  }).join('\n');
+}
+
+export default {
+  getWorklogs,
+  addWorklog,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import atlassianProjectsTools from './tools/atlassian.projects.tool.js';
 import atlassianIssuesTools from './tools/atlassian.issues.tool.js';
 import atlassianStatusesTools from './tools/atlassian.statuses.tool.js';
 import atlassianCommentsTools from './tools/atlassian.comments.tool.js';
+import atlassianWorklogsTools from './tools/atlassian.worklogs.tool.js';
 
 // Create a contextualized logger for this file
 const indexLogger = Logger.forContext('index.ts');
@@ -77,6 +78,9 @@ export async function startServer(mode: 'stdio' | 'sse' = 'stdio') {
 
 	atlassianCommentsTools.registerTools(serverInstance);
 	serverLogger.debug('Registered Comments tools');
+
+	atlassianWorklogsTools.registerTools(serverInstance);
+	serverLogger.debug('Registered Worklogs tools');
 
 	serverLogger.info('All tools registered successfully');
 

--- a/src/tools/atlassian.worklogs.tool.ts
+++ b/src/tools/atlassian.worklogs.tool.ts
@@ -1,0 +1,120 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Logger } from '../utils/logger.util.js';
+import { formatErrorForMcpTool } from '../utils/error.util.js';
+import {
+  AddWorklogParams,
+  GetWorklogsParams,
+} from './atlassian.worklogs.types.js';
+import atlassianWorklogsController from '../controllers/atlassian.worklogs.controller.js';
+
+// Create a contextualized logger for this file
+const toolLogger = Logger.forContext('tools/atlassian.worklogs.tool.ts');
+
+// Log tool module initialization
+toolLogger.debug('Jira worklogs tool module initialized');
+
+/**
+ * MCP Tool: Get Jira Worklogs
+ *
+ * Retrieves worklogs for a specific Jira issue.
+ * Returns a formatted markdown response with worklog details.
+ *
+ * @param {GetWorklogsParams} args - Tool arguments containing the issue ID/key
+ * @returns {Promise<{ content: Array<{ type: 'text', text: string }> }>} MCP response with formatted worklogs
+ * @throws Will return error message if worklog retrieval fails
+ */
+async function getWorklogs(args: GetWorklogsParams) {
+  const methodLogger = Logger.forContext(
+    'tools/atlassian.worklogs.tool.ts',
+    'getWorklogs',
+  );
+  methodLogger.debug(`Retrieving worklogs for issue: ${args.issueIdOrKey}`);
+
+  try {
+    const result = await atlassianWorklogsController.getWorklogs(args);
+    methodLogger.debug('Successfully retrieved worklogs');
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: result.content,
+        },
+      ],
+    };
+  } catch (error) {
+    methodLogger.error('Failed to get worklogs', error);
+    return formatErrorForMcpTool(error);
+  }
+}
+
+/**
+ * MCP Tool: Add Jira Worklog
+ *
+ * Adds a new worklog to a specific Jira issue.
+ * Returns a formatted markdown response confirming the addition.
+ *
+ * @param {AddWorklogParams} args - Tool arguments containing worklog details
+ * @returns {Promise<{ content: Array<{ type: 'text', text: string }> }>} MCP response with confirmation
+ * @throws Will return error message if worklog addition fails
+ */
+async function addWorklog(args: AddWorklogParams) {
+  const methodLogger = Logger.forContext(
+    'tools/atlassian.worklogs.tool.ts',
+    'addWorklog',
+  );
+  methodLogger.debug(`Adding worklog to issue: ${args.issueIdOrKey}`);
+
+  try {
+    const result = await atlassianWorklogsController.addWorklog(args);
+    methodLogger.debug('Successfully added worklog');
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: result.content,
+        },
+      ],
+    };
+  } catch (error) {
+    methodLogger.error('Failed to add worklog', error);
+    return formatErrorForMcpTool(error);
+  }
+}
+
+/**
+ * Register Atlassian Worklogs MCP Tools
+ *
+ * Registers the get-worklogs and add-worklog tools with the MCP server.
+ * Each tool is registered with its schema, description, and handler function.
+ *
+ * @param {McpServer} server - The MCP server instance to register tools with
+ */
+function registerTools(server: McpServer) {
+  const methodLogger = Logger.forContext(
+    'tools/atlassian.worklogs.tool.ts',
+    'registerTools',
+  );
+  methodLogger.debug('Registering Atlassian Worklogs tools...');
+
+  // Register the get worklogs tool
+  server.tool(
+    'jira_ls_worklogs',
+    `Lists worklogs for a specific Jira issue. Returns a formatted list of worklogs including author, time spent, start time, and comments.`,
+    GetWorklogsParams.shape,
+    getWorklogs,
+  );
+
+  // Register the add worklog tool
+  server.tool(
+    'jira_add_worklog',
+    `Adds a new worklog to a specific Jira issue. Requires the issue ID/key and time spent in seconds. Optionally accepts a comment and start time.`,
+    AddWorklogParams.shape,
+    addWorklog,
+  );
+
+  methodLogger.debug('Successfully registered Atlassian Worklogs tools');
+}
+
+export default { registerTools };

--- a/src/tools/atlassian.worklogs.types.ts
+++ b/src/tools/atlassian.worklogs.types.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+export const GetWorklogsParams = z.object({
+  issueIdOrKey: z.string().min(1).describe('The ID or key of the Jira issue to get worklogs from (e.g., "PROJ-123" or "10001").'),
+});
+
+export const AddWorklogParams = z.object({
+  issueIdOrKey: z.string().min(1).describe('The ID or key of the Jira issue to add a worklog to (e.g., "PROJ-123" or "10001").'),
+  timeSpentSeconds: z.number().min(1).describe('Time spent in seconds. For example, use 3600 for 1 hour.'),
+  comment: z.string().optional().describe('Optional comment to add to the worklog.'),
+  started: z.string().optional().describe('Optional start time in ISO 8601 format. Defaults to now if not provided.'),
+});
+
+export type GetWorklogsParams = z.infer<typeof GetWorklogsParams>;
+export type AddWorklogParams = z.infer<typeof AddWorklogParams>;
+
+export interface Worklog {
+  id: string;
+  timeSpentSeconds: number;
+  started: string;
+  author: {
+    accountId: string;
+    displayName: string;
+  };
+  comment?: {
+    type: string;
+    version: number;
+    content: Array<{
+      type: string;
+      content: Array<{
+        type: string;
+        text: string;
+      }>;
+    }>;
+  };
+}
+
+export interface DeleteWorklogParams {
+  issueIdOrKey: string;
+  worklogId: string;
+}
+
+export interface UpdateWorklogParams extends AddWorklogParams {
+  worklogId: string;
+}
+
+export interface WorklogResponse {
+  worklogs: Worklog[];
+}


### PR DESCRIPTION
This PR adds worklog functionality to the Jira MCP server:

### Features
- Added `jira_ls_worklogs` tool to list worklogs for an issue
- Added `jira_add_worklog` tool to add new worklogs to an issue
- Implemented proper error handling and type validation using Zod
- Added integration with MCP server registration system

### Implementation Details
- Created new types in `atlassian.worklogs.types.ts`
- Implemented tools in `atlassian.worklogs.tool.ts`
- Added controller in `atlassian.worklogs.controller.ts`
- Registered tools in `index.ts`

### Testing
Successfully tested by:
- Adding a 1-hour worklog to DEMO-10
- Listing worklogs showing the new entry along with 26 previous worklog entries