### PR TITLE
fix: prevent dotenv from outputting to STDIO in MCP mode

### DIFF
--- a/src/utils/config.util.ts
+++ b/src/utils/config.util.ts
@@ -68,7 +68,9 @@ class ConfigLoader {
 		);
 
 		try {
-			const result = dotenv.config();
+			// Use quiet mode to prevent dotenv from outputting to STDIO
+			// which interferes with MCP's JSON-RPC communication
+			const result = dotenv.config({ quiet: true });
 			if (result.error) {
 				methodLogger.debug(
 					'[src/utils/config.util.ts@loadFromEnvFile] No .env file found or error reading it',


### PR DESCRIPTION
## Problem
The `dotenv.config()` call was outputting log messages to STDIO, which interfered with MCP's JSON-RPC communication in Claude Desktop. This caused "Unexpected token" JSON parsing errors when using STDIO transport mode.

**Error message:**
```
Unexpected token 'd', "[dotenv@17."... is not valid JSON
```

**Root cause:** 
dotenv was outputting messages like `[dotenv@17.2.2] injecting env (0) from .env` to STDIO, which broke the JSON-RPC protocol used by MCP servers.

## Solution
Added `{ quiet: true }` option to `dotenv.config()` call to suppress these log messages.

**Changes:**
- Modified `src/utils/config.util.ts`
- Added explanatory comment
- No functional changes to environment variable loading behavior

## Testing Results
- ✅ Formatter: PASS
- ✅ Linter: PASS  
- ✅ Build: PASS
- ✅ MCP STDIO transport mode verified working
- ✅ No regression in environment variable loading

## Impact
This fix resolves STDIO interference for all Claude Desktop users without requiring any configuration changes on their part. Critical fix for MCP protocol compatibility.

Based on the fix originally proposed in [mcp-server-atlassian-bitbucket#106](https://github.com/aashari/mcp-server-atlassian-bitbucket/pull/106) by @hansonkim.